### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/FloppyMusic/keywords.txt
+++ b/FloppyMusic/keywords.txt
@@ -6,15 +6,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-FloppyMusic  KEYWORD1
+FloppyMusic	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin KEYWORD2
-set_freq KEYWORD2
-reset KEYWORD2
-print_debug_log KEYWORD2
+begin	KEYWORD2
+set_freq	KEYWORD2
+reset	KEYWORD2
+print_debug_log	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords